### PR TITLE
Unit Tests for Product Service

### DIFF
--- a/ERP_Backend.slnx
+++ b/ERP_Backend.slnx
@@ -8,4 +8,7 @@
     <Project Path="tests/src/ApiGateway.Tests/ApiGateway.Tests.csproj" />
     <Project Path="tests/src/AuthService.Tests/AuthService.Tests.csproj" />
   </Folder>
+  <Folder Name="/tests/src/">
+    <Project Path="tests/src/ProductService.Tests/ProductService.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/tests/src/ProductService.Tests/Controllers/ProductsControllerTests.cs
+++ b/tests/src/ProductService.Tests/Controllers/ProductsControllerTests.cs
@@ -1,0 +1,341 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using ProductService.Controllers;
+using ProductService.DTOs;
+using ProductService.Interfaces;
+
+namespace ProductService.Tests.Controllers;
+
+/// <summary>
+/// Unit tests for <see cref="ProductsController"/> — product and stock endpoints.
+/// The controller is tested in isolation using a mocked <see cref="IProductManager"/>.
+/// </summary>
+public class ProductsControllerTests
+{
+    // ─── Helpers ────────────────────────────────────────────────────────────────
+
+    private static ProductsController CreateController(IProductManager manager)
+    {
+        var controller = new ProductsController(manager);
+
+        // Provide a minimal HttpContext so Response.Headers can be written
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        return controller;
+    }
+
+    private static ProductResponseDto SampleProduct(Guid? id = null) => new()
+    {
+        Id                = id ?? Guid.NewGuid(),
+        Sku               = "SKU-001",
+        Name              = "Test Widget",
+        Price             = 9.99m,
+        IsActive          = true,
+        QuantityAvailable = 50,
+        LowStockThreshold = 10,
+        IsLowStock        = false
+    };
+
+    // ─── GET /api/products ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetProducts_ValidParameters_ReturnsOkWithData()
+    {
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.GetProductsAsync(1, 10, null, null, null))
+            .ReturnsAsync(new PaginatedResponse<ProductResponseDto>
+            {
+                Data         = [SampleProduct()],
+                PageNumber   = 1,
+                PageSize     = 10,
+                TotalRecords = 1
+            });
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.GetProducts(1, 10);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(ok.Value);
+    }
+
+    [Theory]
+    [InlineData(0, 10)]
+    [InlineData(1, 0)]
+    [InlineData(0, 0)]
+    public async Task GetProducts_InvalidPagination_ReturnsBadRequest(int page, int size)
+    {
+        var mock       = new Mock<IProductManager>();
+        var controller = CreateController(mock.Object);
+
+        var result = await controller.GetProducts(page, size);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    // ─── GET /api/products/{id} ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetProductById_ExistingId_ReturnsOkWithProduct()
+    {
+        var productId = Guid.NewGuid();
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.GetProductByIdAsync(productId))
+            .ReturnsAsync(SampleProduct(productId));
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.GetProductById(productId);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var body = Assert.IsType<ProductResponseDto>(ok.Value);
+        Assert.Equal(productId, body.Id);
+    }
+
+    [Fact]
+    public async Task GetProductById_NonExistentId_ReturnsNotFound()
+    {
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.GetProductByIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync((ProductResponseDto?)null);
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.GetProductById(Guid.NewGuid());
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // ─── GET /api/products/stock ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStock_ReturnsOkWithStockList()
+    {
+        var stocks = new List<StockResponseDto>
+        {
+            new() { ProductId = Guid.NewGuid(), Name = "Widget A", QuantityAvailable = 100 }
+        };
+
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.GetStockAsync()).ReturnsAsync(stocks);
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.GetStock();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(ok.Value);
+    }
+
+    // ─── GET /api/products/{id}/stock ───────────────────────────────────────
+
+    [Fact]
+    public async Task GetStockByProductId_ExistingProduct_ReturnsOk()
+    {
+        var productId = Guid.NewGuid();
+        var stock = new StockResponseDto { ProductId = productId, QuantityAvailable = 20 };
+
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.GetStockByProductIdAsync(productId)).ReturnsAsync(stock);
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.GetStockByProductId(productId);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var body = Assert.IsType<StockResponseDto>(ok.Value);
+        Assert.Equal(productId, body.ProductId);
+    }
+
+    [Fact]
+    public async Task GetStockByProductId_NonExistentProduct_ReturnsNotFound()
+    {
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.GetStockByProductIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync((StockResponseDto?)null);
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.GetStockByProductId(Guid.NewGuid());
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // ─── PUT /api/products/{id} ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateProduct_ExistingId_ReturnsOkWithUpdatedProduct()
+    {
+        var productId = Guid.NewGuid();
+        var updated   = SampleProduct(productId);
+        updated.Name  = "Updated Widget";
+
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.UpdateProductAsync(productId, It.IsAny<UpdateProductDto>()))
+            .ReturnsAsync(updated);
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.UpdateProduct(productId, new UpdateProductDto
+        {
+            Sku               = "SKU-001",
+            Name              = "Updated Widget",
+            Price             = 19.99m,
+            QuantityAvailable = 40,
+            LowStockThreshold = 5
+        });
+
+        var ok   = Assert.IsType<OkObjectResult>(result);
+        var body = Assert.IsType<ProductResponseDto>(ok.Value);
+        Assert.Equal("Updated Widget", body.Name);
+    }
+
+    [Fact]
+    public async Task UpdateProduct_NonExistentId_ReturnsNotFound()
+    {
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.UpdateProductAsync(It.IsAny<Guid>(), It.IsAny<UpdateProductDto>()))
+            .ReturnsAsync((ProductResponseDto?)null);
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.UpdateProduct(Guid.NewGuid(), new UpdateProductDto
+        {
+            Sku               = "SKU-X",
+            Name              = "Ghost",
+            Price             = 1m,
+            QuantityAvailable = 0,
+            LowStockThreshold = 5
+        });
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // ─── DELETE /api/products/{id} ───────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteProduct_ExistingId_ReturnsNoContent()
+    {
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.DeleteProductAsync(It.IsAny<Guid>())).ReturnsAsync(true);
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.DeleteProduct(Guid.NewGuid());
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteProduct_NonExistentId_ReturnsNotFound()
+    {
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.DeleteProductAsync(It.IsAny<Guid>())).ReturnsAsync(false);
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.DeleteProduct(Guid.NewGuid());
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // ─── POST /api/products/deduct-stock ────────────────────────────────────
+
+    [Fact]
+    public async Task DeductStock_SufficientStock_ReturnsOk()
+    {
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.DeductStockAsync(It.IsAny<DeductStockDto>()))
+            .ReturnsAsync((true, "Stock deducted successfully. Remaining: 45."));
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.DeductStock(new DeductStockDto
+        {
+            ProductId = Guid.NewGuid(),
+            OrderId   = Guid.NewGuid(),
+            Quantity  = 5
+        });
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task DeductStock_InsufficientStock_ReturnsConflict()
+    {
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.DeductStockAsync(It.IsAny<DeductStockDto>()))
+            .ReturnsAsync((false, "Insufficient stock. Available: 2, Requested: 10."));
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.DeductStock(new DeductStockDto
+        {
+            ProductId = Guid.NewGuid(),
+            OrderId   = Guid.NewGuid(),
+            Quantity  = 10
+        });
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+
+    // ─── GET /api/products/alerts ────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAlerts_ReturnsOkWithAlertList()
+    {
+        var alerts = new List<LowStockAlertDto>
+        {
+            new() { Id = Guid.NewGuid(), ProductId = Guid.NewGuid(), ProductName = "Widget A", IsResolved = false }
+        };
+
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.GetLowStockAlertsAsync(false)).ReturnsAsync(alerts);
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.GetAlerts(unresolvedOnly: false);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(ok.Value);
+    }
+
+    // ─── PATCH /api/products/alerts/{id}/resolve ─────────────────────────────
+
+    [Fact]
+    public async Task ResolveAlert_ExistingAlert_ReturnsOk()
+    {
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.ResolveAlertAsync(It.IsAny<Guid>())).ReturnsAsync(true);
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.ResolveAlert(Guid.NewGuid());
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task ResolveAlert_NonExistentAlert_ReturnsNotFound()
+    {
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.ResolveAlertAsync(It.IsAny<Guid>())).ReturnsAsync(false);
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.ResolveAlert(Guid.NewGuid());
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // ─── GET /api/products/search/{name} ────────────────────────────────────
+
+    [Fact]
+    public async Task SearchProductsByName_ValidName_ReturnsOkWithResults()
+    {
+        var mock = new Mock<IProductManager>();
+        mock.Setup(m => m.GetProductsAsync(1, 100, null, null, "widget"))
+            .ReturnsAsync(new PaginatedResponse<ProductResponseDto>
+            {
+                Data         = [SampleProduct()],
+                PageNumber   = 1,
+                PageSize     = 100,
+                TotalRecords = 1
+            });
+
+        var controller = CreateController(mock.Object);
+        var result = await controller.SearchProductsByName("widget");
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(ok.Value);
+    }
+}

--- a/tests/src/ProductService.Tests/Helpers/DbContextFactory.cs
+++ b/tests/src/ProductService.Tests/Helpers/DbContextFactory.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using ProductService.Data;
+
+namespace ProductService.Tests.Helpers;
+
+/// <summary>
+/// Creates a fresh, isolated in-memory <see cref="ProductDbContext"/> for every test.
+/// Each call returns a context backed by a uniquely named database so that tests
+/// never share state.
+/// </summary>
+internal static class DbContextFactory
+{
+    public static ProductDbContext Create(string? dbName = null)
+    {
+        var options = new DbContextOptionsBuilder<ProductDbContext>()
+            .UseInMemoryDatabase(dbName ?? Guid.NewGuid().ToString())
+            .Options;
+
+        return new ProductDbContext(options);
+    }
+}

--- a/tests/src/ProductService.Tests/ProductService.Tests.csproj
+++ b/tests/src/ProductService.Tests/ProductService.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\ProductService\ProductService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/src/ProductService.Tests/Services/ProductManagerTests_Alerts.cs
+++ b/tests/src/ProductService.Tests/Services/ProductManagerTests_Alerts.cs
@@ -1,0 +1,213 @@
+using ProductService.DTOs;
+using ProductService.Models;
+using ProductService.Services;
+using ProductService.Tests.Helpers;
+
+namespace ProductService.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ProductManager"/> — low-stock alert management.
+/// Covers GetLowStockAlertsAsync and ResolveAlertAsync.
+/// </summary>
+public class ProductManagerTests_Alerts
+{
+    // ─── Helpers ────────────────────────────────────────────────────────────────
+
+    private static CreateProductDto MakeCreateDto(
+        string sku = "SKU-A",
+        string name = "Alert Widget",
+        int initialStock = 50,
+        int lowStockThreshold = 10) => new()
+    {
+        Sku               = sku,
+        Name              = name,
+        Price             = 5.00m,
+        IsActive          = true,
+        InitialStock      = initialStock,
+        LowStockThreshold = lowStockThreshold
+    };
+
+    private static async Task<(ProductManager manager, Guid productId, Guid alertId)>
+        SetupWithAlertAsync(string dbName)
+    {
+        var ctx     = DbContextFactory.Create(dbName);
+        var manager = new ProductManager(ctx);
+
+        // Create product with stock above threshold
+        var created = await manager.CreateProductAsync(MakeCreateDto(initialStock: 15, lowStockThreshold: 10), Guid.NewGuid());
+
+        // Trigger low-stock alert by deducting stock below the threshold
+        await manager.DeductStockAsync(new DeductStockDto
+        {
+            ProductId = created.Id,
+            OrderId   = Guid.NewGuid(),
+            Quantity  = 10     // 15 - 10 = 5, which is ≤ threshold(10)
+        });
+
+        var alertId = ctx.LowStockAlerts
+            .Single(a => a.ProductId == created.Id && !a.IsResolved)
+            .Id;
+
+        return (manager, created.Id, alertId);
+    }
+
+    // ─── GetLowStockAlertsAsync ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetLowStockAlertsAsync_NoFilter_ReturnsAllAlerts()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var (manager, productId, alertId) = await SetupWithAlertAsync(dbName);
+
+        // Also manually resolve one alert so we have both resolved & unresolved
+        await manager.ResolveAlertAsync(alertId);
+
+        // Add an un-resolved alert directly for another product to keep totals clear
+        var ctx2 = DbContextFactory.Create(dbName);
+        var manager2 = new ProductManager(ctx2);
+
+        // the first alert is now resolved; create another product & alert
+        var created2 = await manager2.CreateProductAsync(MakeCreateDto("SKU-Z", "Another", 12, 10), Guid.NewGuid());
+        await manager2.DeductStockAsync(new DeductStockDto { ProductId = created2.Id, OrderId = Guid.NewGuid(), Quantity = 10 });
+
+        var alerts = (await manager2.GetLowStockAlertsAsync(unresolvedOnly: false)).ToList();
+
+        Assert.Equal(2, alerts.Count);
+    }
+
+    [Fact]
+    public async Task GetLowStockAlertsAsync_UnresolvedOnly_ExcludesResolvedAlerts()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var (manager, _, alertId) = await SetupWithAlertAsync(dbName);
+
+        // Resolve the only alert
+        await manager.ResolveAlertAsync(alertId);
+
+        var alerts = (await manager.GetLowStockAlertsAsync(unresolvedOnly: true)).ToList();
+
+        Assert.Empty(alerts);
+    }
+
+    [Fact]
+    public async Task GetLowStockAlertsAsync_UnresolvedOnly_ReturnsOpenAlerts()
+    {
+        var (manager, _, _) = await SetupWithAlertAsync(Guid.NewGuid().ToString());
+
+        var alerts = (await manager.GetLowStockAlertsAsync(unresolvedOnly: true)).ToList();
+
+        Assert.Single(alerts);
+        Assert.False(alerts[0].IsResolved);
+    }
+
+    [Fact]
+    public async Task GetLowStockAlertsAsync_ReturnsCorrectAlertData()
+    {
+        var (manager, productId, _) = await SetupWithAlertAsync(Guid.NewGuid().ToString());
+
+        var alerts = (await manager.GetLowStockAlertsAsync()).ToList();
+
+        Assert.Single(alerts);
+        var alert = alerts[0];
+        Assert.Equal(productId, alert.ProductId);
+        Assert.Equal(5,         alert.QuantityAtAlert);   // 15 - 10 = 5
+        Assert.False(alert.IsResolved);
+        Assert.Null(alert.ResolvedAt);
+    }
+
+    // ─── ResolveAlertAsync ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveAlertAsync_ExistingAlert_ReturnsTrueAndMarksResolved()
+    {
+        var (manager, _, alertId) = await SetupWithAlertAsync(Guid.NewGuid().ToString());
+
+        var result = await manager.ResolveAlertAsync(alertId);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task ResolveAlertAsync_NonExistentAlert_ReturnsFalse()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var result = await manager.ResolveAlertAsync(Guid.NewGuid());
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ResolveAlertAsync_SetsIsResolvedAndResolvedAt()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var (manager, _, alertId) = await SetupWithAlertAsync(dbName);
+
+        var before = DateTime.UtcNow;
+        await manager.ResolveAlertAsync(alertId);
+
+        // Re-open context to read the persisted state
+        var ctx2  = DbContextFactory.Create(dbName);
+        var alert = ctx2.LowStockAlerts.Single(a => a.Id == alertId);
+
+        Assert.True(alert.IsResolved);
+        Assert.NotNull(alert.ResolvedAt);
+        Assert.True(alert.ResolvedAt >= before);
+    }
+
+    // ─── Auto-resolve on restock ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateProductAsync_WhenStockRestockedAboveThreshold_AutoResolvesOpenAlert()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var (manager, productId, alertId) = await SetupWithAlertAsync(dbName);
+
+        // Restock above threshold via update
+        var updateDto = new UpdateProductDto
+        {
+            Sku               = "SKU-A",
+            Name              = "Alert Widget",
+            Price             = 5.00m,
+            IsActive          = true,
+            QuantityAvailable = 50,   // well above threshold
+            LowStockThreshold = 10
+        };
+
+        await manager.UpdateProductAsync(productId, updateDto);
+
+        var ctx2  = DbContextFactory.Create(dbName);
+        var alert = ctx2.LowStockAlerts.Single(a => a.Id == alertId);
+        Assert.True(alert.IsResolved);
+        Assert.NotNull(alert.ResolvedAt);
+    }
+
+    [Fact]
+    public async Task UpdateProductAsync_WhenStockStillLow_DoesNotCreateDuplicateAlert()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var (manager, productId, _) = await SetupWithAlertAsync(dbName);
+
+        // Keep stock below threshold
+        var updateDto = new UpdateProductDto
+        {
+            Sku               = "SKU-A",
+            Name              = "Alert Widget",
+            Price             = 5.00m,
+            IsActive          = true,
+            QuantityAvailable = 3,    // still ≤ threshold(10)
+            LowStockThreshold = 10
+        };
+
+        await manager.UpdateProductAsync(productId, updateDto);
+
+        var ctx2   = DbContextFactory.Create(dbName);
+        var alerts = ctx2.LowStockAlerts
+            .Where(a => a.ProductId == productId && !a.IsResolved)
+            .ToList();
+
+        // Should still be exactly ONE unresolved alert (no duplicate)
+        Assert.Single(alerts);
+    }
+}

--- a/tests/src/ProductService.Tests/Services/ProductManagerTests_Products.cs
+++ b/tests/src/ProductService.Tests/Services/ProductManagerTests_Products.cs
@@ -1,0 +1,278 @@
+using ProductService.DTOs;
+using ProductService.Models;
+using ProductService.Services;
+using ProductService.Tests.Helpers;
+
+namespace ProductService.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ProductManager"/> — product CRUD operations.
+/// Uses the EF Core in-memory provider so no real database is required.
+/// </summary>
+public class ProductManagerTests_Products
+{
+    // ─── Helpers ────────────────────────────────────────────────────────────────
+
+    private static CreateProductDto MakeCreateDto(
+        string sku = "SKU-001",
+        string name = "Test Widget",
+        decimal price = 9.99m,
+        int initialStock = 50,
+        int lowStockThreshold = 10,
+        int? categoryId = null) => new()
+    {
+        Sku              = sku,
+        Name             = name,
+        Description      = "A unit-test product",
+        CategoryId       = categoryId,
+        Price            = price,
+        IsActive         = true,
+        InitialStock     = initialStock,
+        LowStockThreshold = lowStockThreshold
+    };
+
+    private static UpdateProductDto MakeUpdateDto(
+        string sku = "SKU-001-UP",
+        string name = "Updated Widget",
+        decimal price = 19.99m,
+        int qty = 40,
+        int threshold = 5) => new()
+    {
+        Sku               = sku,
+        Name              = name,
+        Description       = "Updated description",
+        CategoryId        = null,
+        Price             = price,
+        IsActive          = true,
+        QuantityAvailable = qty,
+        LowStockThreshold = threshold
+    };
+
+    // ─── GetProductByIdAsync ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetProductByIdAsync_ExistingId_ReturnsMatchingProduct()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+        var userId = Guid.NewGuid();
+
+        var created = await manager.CreateProductAsync(MakeCreateDto(), userId);
+
+        var result = await manager.GetProductByIdAsync(created.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal(created.Id, result.Id);
+        Assert.Equal("Test Widget", result.Name);
+        Assert.Equal("SKU-001", result.Sku);
+    }
+
+    [Fact]
+    public async Task GetProductByIdAsync_NonExistentId_ReturnsNull()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var result = await manager.GetProductByIdAsync(Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    // ─── GetProductsAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetProductsAsync_NoFilter_ReturnsAllProducts()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+        var userId = Guid.NewGuid();
+
+        await manager.CreateProductAsync(MakeCreateDto("SKU-A", "Alpha"), userId);
+        await manager.CreateProductAsync(MakeCreateDto("SKU-B", "Beta"),  userId);
+
+        var result = await manager.GetProductsAsync(1, 10, null, null, null);
+
+        Assert.Equal(2, result.TotalRecords);
+        Assert.Equal(2, result.Data.Count());
+    }
+
+    [Fact]
+    public async Task GetProductsAsync_FilterByName_ReturnsMatchingProduct()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+        var userId = Guid.NewGuid();
+
+        await manager.CreateProductAsync(MakeCreateDto("SKU-A", "Alpha Widget"), userId);
+        await manager.CreateProductAsync(MakeCreateDto("SKU-B", "Beta Gadget"),  userId);
+
+        var result = await manager.GetProductsAsync(1, 10, null, null, "gadget");
+
+        Assert.Equal(1, result.TotalRecords);
+        Assert.Equal("Beta Gadget", result.Data.Single().Name);
+    }
+
+    [Fact]
+    public async Task GetProductsAsync_Pagination_RespectsPageSizeAndOffset()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+        var userId = Guid.NewGuid();
+
+        // Insert 5 products (ordered alphabetically by name)
+        foreach (var i in Enumerable.Range(1, 5))
+            await manager.CreateProductAsync(MakeCreateDto($"SKU-{i:D2}", $"Product {i:D2}"), userId);
+
+        var page1 = await manager.GetProductsAsync(1, 2, null, null, null);
+        var page2 = await manager.GetProductsAsync(2, 2, null, null, null);
+
+        Assert.Equal(5, page1.TotalRecords);
+        Assert.Equal(2, page1.Data.Count());
+        Assert.Equal(2, page2.Data.Count());
+
+        // Ensure page 1 and page 2 contain different products
+        var page1Ids = page1.Data.Select(p => p.Id).ToHashSet();
+        var page2Ids = page2.Data.Select(p => p.Id).ToHashSet();
+        Assert.Empty(page1Ids.Intersect(page2Ids));
+    }
+
+    [Fact]
+    public async Task GetProductsAsync_FilterByCategoryId_ReturnsOnlyMatchingProducts()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+        var userId = Guid.NewGuid();
+
+        var dto1 = MakeCreateDto("SKU-C1", "Cat-1 Product", categoryId: 42);
+        var dto2 = MakeCreateDto("SKU-C2", "Cat-2 Product", categoryId: 99);
+
+        await manager.CreateProductAsync(dto1, userId);
+        await manager.CreateProductAsync(dto2, userId);
+
+        var result = await manager.GetProductsAsync(1, 10, null, 42, null);
+
+        Assert.Equal(1, result.TotalRecords);
+        Assert.Equal("Cat-1 Product", result.Data.Single().Name);
+    }
+
+    // ─── CreateProductAsync ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateProductAsync_ValidDto_ReturnsCreatedProduct()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+        var userId = Guid.NewGuid();
+
+        var result = await manager.CreateProductAsync(MakeCreateDto(), userId);
+
+        Assert.NotEqual(Guid.Empty, result.Id);
+        Assert.Equal("Test Widget", result.Name);
+        Assert.Equal("SKU-001", result.Sku);
+        Assert.Equal(9.99m, result.Price);
+        Assert.Equal(50, result.QuantityAvailable);
+        Assert.Equal(10, result.LowStockThreshold);
+        Assert.Equal(userId, result.CreatedByUserId);
+    }
+
+    [Fact]
+    public async Task CreateProductAsync_CreatesInventoryRecord()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var result = await manager.CreateProductAsync(MakeCreateDto(initialStock: 100, lowStockThreshold: 20), Guid.NewGuid());
+
+        var inventory = ctx.Inventory.Single(i => i.ProductId == result.Id);
+        Assert.Equal(100, inventory.QuantityAvailable);
+        Assert.Equal(20, inventory.LowStockThreshold);
+        Assert.Equal(0,  inventory.QuantityReserved);
+    }
+
+    [Fact]
+    public async Task CreateProductAsync_PersistsProductInDatabase()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var result = await manager.CreateProductAsync(MakeCreateDto(), Guid.NewGuid());
+
+        var persisted = ctx.Products.Single(p => p.Id == result.Id);
+        Assert.Equal("Test Widget", persisted.Name);
+        Assert.Equal("SKU-001", persisted.Sku);
+    }
+
+    // ─── UpdateProductAsync ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateProductAsync_ExistingId_ReturnsUpdatedProduct()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var created = await manager.CreateProductAsync(MakeCreateDto(), Guid.NewGuid());
+        var updateDto = MakeUpdateDto(qty: 30, threshold: 5);
+
+        var result = await manager.UpdateProductAsync(created.Id, updateDto);
+
+        Assert.NotNull(result);
+        Assert.Equal("Updated Widget",  result.Name);
+        Assert.Equal("SKU-001-UP",      result.Sku);
+        Assert.Equal(19.99m,            result.Price);
+        Assert.Equal(30,                result.QuantityAvailable);
+        Assert.Equal(5,                 result.LowStockThreshold);
+    }
+
+    [Fact]
+    public async Task UpdateProductAsync_NonExistentId_ReturnsNull()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var result = await manager.UpdateProductAsync(Guid.NewGuid(), MakeUpdateDto());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UpdateProductAsync_UpdatesInventoryRecord()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var created = await manager.CreateProductAsync(MakeCreateDto(initialStock: 50, lowStockThreshold: 10), Guid.NewGuid());
+
+        await manager.UpdateProductAsync(created.Id, MakeUpdateDto(qty: 80, threshold: 15));
+
+        var inventory = ctx.Inventory.Single(i => i.ProductId == created.Id);
+        Assert.Equal(80, inventory.QuantityAvailable);
+        Assert.Equal(15, inventory.LowStockThreshold);
+    }
+
+    // ─── DeleteProductAsync ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteProductAsync_ExistingId_ReturnsTrueAndRemovesProduct()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var created = await manager.CreateProductAsync(MakeCreateDto(), Guid.NewGuid());
+
+        var deleted = await manager.DeleteProductAsync(created.Id);
+
+        Assert.True(deleted);
+        Assert.False(ctx.Products.Any(p => p.Id == created.Id));
+    }
+
+    [Fact]
+    public async Task DeleteProductAsync_NonExistentId_ReturnsFalse()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var result = await manager.DeleteProductAsync(Guid.NewGuid());
+
+        Assert.False(result);
+    }
+}

--- a/tests/src/ProductService.Tests/Services/ProductManagerTests_Stock.cs
+++ b/tests/src/ProductService.Tests/Services/ProductManagerTests_Stock.cs
@@ -1,0 +1,255 @@
+using ProductService.DTOs;
+using ProductService.Services;
+using ProductService.Tests.Helpers;
+
+namespace ProductService.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ProductManager"/> — stock deduction and stock query operations.
+/// </summary>
+public class ProductManagerTests_Stock
+{
+    // ─── Helpers ────────────────────────────────────────────────────────────────
+
+    private static CreateProductDto MakeCreateDto(
+        string sku = "SKU-001",
+        string name = "Stock Widget",
+        int initialStock = 50,
+        int lowStockThreshold = 10) => new()
+    {
+        Sku               = sku,
+        Name              = name,
+        Price             = 9.99m,
+        IsActive          = true,
+        InitialStock      = initialStock,
+        LowStockThreshold = lowStockThreshold
+    };
+
+    // ─── GetStockAsync ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStockAsync_ReturnsOnlyActiveProducts()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+        var userId  = Guid.NewGuid();
+
+        // Active product
+        await manager.CreateProductAsync(MakeCreateDto("SKU-A", "Active Product"), userId);
+
+        // Inactive product – insert directly so we can mark IsActive = false
+        var inactiveDto = MakeCreateDto("SKU-B", "Inactive Product");
+        var inactive = await manager.CreateProductAsync(inactiveDto, userId);
+        var product  = ctx.Products.Single(p => p.Id == inactive.Id);
+        product.IsActive = false;
+        await ctx.SaveChangesAsync();
+
+        var stocks = (await manager.GetStockAsync()).ToList();
+
+        Assert.Single(stocks);
+        Assert.Equal("Active Product", stocks[0].Name);
+    }
+
+    [Fact]
+    public async Task GetStockAsync_ReturnsCorrectStockData()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var created = await manager.CreateProductAsync(MakeCreateDto(initialStock: 75, lowStockThreshold: 15), Guid.NewGuid());
+
+        var stocks = (await manager.GetStockAsync()).ToList();
+
+        Assert.Single(stocks);
+        var stock = stocks[0];
+        Assert.Equal(created.Id, stock.ProductId);
+        Assert.Equal(75,         stock.QuantityAvailable);
+        Assert.Equal(15,         stock.LowStockThreshold);
+        Assert.False(stock.IsLowStock);
+    }
+
+    // ─── GetStockByProductIdAsync ────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStockByProductIdAsync_ExistingProduct_ReturnsStock()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var created = await manager.CreateProductAsync(MakeCreateDto(initialStock: 30), Guid.NewGuid());
+
+        var stock = await manager.GetStockByProductIdAsync(created.Id);
+
+        Assert.NotNull(stock);
+        Assert.Equal(created.Id, stock.ProductId);
+        Assert.Equal(30, stock.QuantityAvailable);
+    }
+
+    [Fact]
+    public async Task GetStockByProductIdAsync_NonExistentProduct_ReturnsNull()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var stock = await manager.GetStockByProductIdAsync(Guid.NewGuid());
+
+        Assert.Null(stock);
+    }
+
+    // ─── DeductStockAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeductStockAsync_SufficientStock_ReturnsTrueAndDeductsQuantity()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var created = await manager.CreateProductAsync(MakeCreateDto(initialStock: 50), Guid.NewGuid());
+
+        var dto = new DeductStockDto
+        {
+            ProductId = created.Id,
+            OrderId   = Guid.NewGuid(),
+            Quantity  = 10
+        };
+
+        var (success, message) = await manager.DeductStockAsync(dto);
+
+        Assert.True(success);
+        Assert.Contains("40", message); // "Remaining: 40"
+
+        var inventory = ctx.Inventory.Single(i => i.ProductId == created.Id);
+        Assert.Equal(40, inventory.QuantityAvailable);
+    }
+
+    [Fact]
+    public async Task DeductStockAsync_InsufficientStock_ReturnsFalseWithMessage()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var created = await manager.CreateProductAsync(MakeCreateDto(initialStock: 5), Guid.NewGuid());
+
+        var dto = new DeductStockDto
+        {
+            ProductId = created.Id,
+            OrderId   = Guid.NewGuid(),
+            Quantity  = 20  // more than available
+        };
+
+        var (success, message) = await manager.DeductStockAsync(dto);
+
+        Assert.False(success);
+        Assert.Contains("Insufficient", message);
+    }
+
+    [Fact]
+    public async Task DeductStockAsync_NoInventoryRecord_ReturnsFalse()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var dto = new DeductStockDto
+        {
+            ProductId = Guid.NewGuid(),
+            OrderId   = Guid.NewGuid(),
+            Quantity  = 1
+        };
+
+        var (success, _) = await manager.DeductStockAsync(dto);
+
+        Assert.False(success);
+    }
+
+    [Fact]
+    public async Task DeductStockAsync_CreatesInventoryReservationRecord()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var created = await manager.CreateProductAsync(MakeCreateDto(initialStock: 50), Guid.NewGuid());
+        var orderId = Guid.NewGuid();
+
+        var dto = new DeductStockDto
+        {
+            ProductId = created.Id,
+            OrderId   = orderId,
+            Quantity  = 5
+        };
+
+        await manager.DeductStockAsync(dto);
+
+        var reservation = ctx.InventoryReservations
+            .Single(r => r.ProductId == created.Id && r.OrderId == orderId);
+
+        Assert.Equal(5,          reservation.Quantity);
+        Assert.Equal("DEDUCTED", reservation.Status);
+    }
+
+    [Fact]
+    public async Task DeductStockAsync_WhenStockFallsBelowThreshold_CreatesLowStockAlert()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        // initialStock=15, threshold=10 → becomes low at 10 or below
+        var created = await manager.CreateProductAsync(
+            MakeCreateDto(initialStock: 15, lowStockThreshold: 10), Guid.NewGuid());
+
+        var dto = new DeductStockDto
+        {
+            ProductId = created.Id,
+            OrderId   = Guid.NewGuid(),
+            Quantity  = 10  // 15 - 10 = 5, which is ≤ threshold(10)
+        };
+
+        await manager.DeductStockAsync(dto);
+
+        var alert = ctx.LowStockAlerts.SingleOrDefault(a => a.ProductId == created.Id && !a.IsResolved);
+        Assert.NotNull(alert);
+        Assert.Equal(5, alert.QuantityAtAlert);
+    }
+
+    [Fact]
+    public async Task DeductStockAsync_WhenStockStaysAboveThreshold_DoesNotCreateAlert()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        // initialStock=100, threshold=10 → 100-5=95 is still above threshold
+        var created = await manager.CreateProductAsync(
+            MakeCreateDto(initialStock: 100, lowStockThreshold: 10), Guid.NewGuid());
+
+        var dto = new DeductStockDto
+        {
+            ProductId = created.Id,
+            OrderId   = Guid.NewGuid(),
+            Quantity  = 5
+        };
+
+        await manager.DeductStockAsync(dto);
+
+        Assert.Empty(ctx.LowStockAlerts.Where(a => a.ProductId == created.Id));
+    }
+
+    [Fact]
+    public async Task DeductStockAsync_UpdatesProductQuantityAvailableInProductsTable()
+    {
+        await using var ctx = DbContextFactory.Create();
+        var manager = new ProductManager(ctx);
+
+        var created = await manager.CreateProductAsync(MakeCreateDto(initialStock: 50), Guid.NewGuid());
+
+        var dto = new DeductStockDto
+        {
+            ProductId = created.Id,
+            OrderId   = Guid.NewGuid(),
+            Quantity  = 15
+        };
+
+        await manager.DeductStockAsync(dto);
+
+        var product = ctx.Products.Single(p => p.Id == created.Id);
+        Assert.Equal(35, product.QuantityAvailable);
+    }
+}


### PR DESCRIPTION
# PR Title
[IMS-362] Add Unit Tests for ProductService

---

## Description
This PR introduces a comprehensive unit test suite for the ProductService, covering both the service layer (`ProductManager`) and the controller layer (`ProductsController`).

---

## What's Included

### 📁 New Project
`tests/src/ProductService.Tests/`

| File | Coverage |
|------|--------|
| `Helpers/DbContextFactory.cs` | Shared helper that spins up an isolated EF Core In-Memory database per test |
| `Services/ProductManagerTests_Products.cs` | CRUD operations — GetProducts (filters, pagination), GetProductById, CreateProduct, UpdateProduct, DeleteProduct |
| `Services/ProductManagerTests_Stock.cs` | Stock operations — GetStockAsync, GetStockByProductId, DeductStockAsync (success, insufficient stock, reservation creation, low-stock alert trigger) |
| `Services/ProductManagerTests_Alerts.cs` | Alert lifecycle — GetLowStockAlertsAsync (all / unresolved-only), ResolveAlertAsync, auto-resolve on restock, no-duplicate-alert guard |
| `Controllers/ProductsControllerTests.cs` | Controller endpoints tested using Moq — verifies correct HTTP status codes (200, 204, 400, 404, 409) |

---

## 🧪 Test Results
Total tests: 53
Passed: 53
Failed: 0
Total time: ~8.6s

---

## ⚙️ Tech Stack

- **xUnit** — Test framework  
- **Moq** — Mocking `IProductManager` for controller tests  
- **Microsoft.EntityFrameworkCore.InMemory** — In-memory DB for service-layer tests (no real DB required)

---

## 🧠 Testing Approach

- **Service Layer Tests**
  - Use real `ProductManager` implementation
  - Run against an in-memory EF Core database
  - Validates business logic end-to-end (alerts, reservations, auto-resolve)

- **Controller Layer Tests**
  - Mock `IProductManager` using Moq
  - Focus on HTTP response behavior in isolation


---

## 🔗 Linked Ticket
IMS-362