### PR TITLE
Dev

### DIFF
--- a/src/OrderService/Program.cs
+++ b/src/OrderService/Program.cs
@@ -126,15 +126,12 @@ var app = builder.Build();
 // Global error handler
 app.UseMiddleware<ErrorHandlingMiddleware>();
 
-if (app.Environment.IsDevelopment())
+app.UseSwagger();
+app.UseSwaggerUI(options =>
 {
-    app.UseSwagger();
-    app.UseSwaggerUI(options =>
-    {
-        options.SwaggerEndpoint("v1/swagger.json", "InsightERP OrderService API v1");
-        options.RoutePrefix = "swagger";
-    });
-}
+    options.SwaggerEndpoint("v1/swagger.json", "InsightERP OrderService API v1");
+    options.RoutePrefix = "swagger";
+});
 
 if (!isRunningInContainer)
 {


### PR DESCRIPTION
## Description
Swagger was only enabled in the `Development` environment in OrderService.
This caused the production CD smoke test for `/order/swagger/v1/swagger.json` 
to fail with a 502 error despite the service being healthy. This PR removes 
the `IsDevelopment()` guard so Swagger is accessible in Production.

## Changes Made
- Enabled `UseSwagger()` and `UseSwaggerUI()` in Production for OrderService

## How to Test
1. Merge and let `cd-prod.yml` run on `main`
2. Wait for smoke tests to complete in GitHub Actions
3. Verify the following URL returns 200:
   - `https://<PROD_GATEWAY_FQDN>/order/swagger/v1/swagger.json`

## Screenshots / Logs (if applicable)
Before: CD smoke test failing with `curl: (22) 502` on order swagger endpoint
After: Order swagger smoke test passes

## Related Issues / Tickets
Fixes #<issue-number>