### PR TITLE
fix: give the correct connection string to customer micro service.

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -202,6 +202,24 @@ jobs:
             --resource-group erp-rg \
             --set-env-vars "ConnectionStrings__DefaultConnection=secretref:order-db-conn"
 
+      - name: Configure CustomerService DB connection and service endpoints
+        env:
+          CUSTOMER_DB_CONN: ${{ secrets.AUTH_DB_CONNECTION_STRING_AZURE }}
+        run: |
+          echo ">>> Setting CustomerService DB connection secret and internal service endpoints..."
+          az containerapp secret set \
+            --name customerservice-dev \
+            --resource-group erp-rg \
+            --secrets "customer-db-conn=$CUSTOMER_DB_CONN"
+
+          az containerapp update \
+            --name customerservice-dev \
+            --resource-group erp-rg \
+            --set-env-vars \
+              "ConnectionStrings__DefaultConnection=secretref:customer-db-conn" \
+              "ServiceEndpoints__ProductService=http://productservice-dev" \
+              "ServiceEndpoints__OrderService=http://orderservice-dev"
+
       - name: Configure ForecastService DB connection string
         env:
           FORECAST_DB_CONN: ${{ secrets.AUTH_DB_CONNECTION_STRING_AZURE }}
@@ -233,6 +251,22 @@ jobs:
 
           echo "API_GATEWAY_URL=https://${GATEWAY_FQDN}" >> "$GITHUB_ENV"
 
+      - name: Resolve CustomerService URL
+        shell: bash
+        run: |
+          CUSTOMER_FQDN="$(az containerapp show \
+            --name customerservice-dev \
+            --resource-group erp-rg \
+            --query properties.configuration.ingress.fqdn \
+            -o tsv)"
+
+          if [[ -z "$CUSTOMER_FQDN" ]]; then
+            echo "Failed to resolve CustomerService FQDN."
+            exit 1
+          fi
+
+          echo "CUSTOMER_SERVICE_URL=https://${CUSTOMER_FQDN}" >> "$GITHUB_ENV"
+
       - name: Smoke tests — Service health checks via ApiGateway
         shell: bash
         run: |
@@ -250,6 +284,29 @@ jobs:
           for endpoint in "${ENDPOINTS[@]}"; do
             IFS=':' read -r service path <<< "$endpoint"
             url="${API_GATEWAY_URL}${path}"
+
+            echo ">>> Smoke testing ${service} via ${url}"
+            curl -fsS \
+              --retry 6 \
+              --retry-delay 10 \
+              --retry-all-errors \
+              --connect-timeout 10 \
+              --max-time 30 \
+              "$url"
+            echo
+          done
+
+      - name: Smoke tests — CustomerService direct endpoints
+        shell: bash
+        run: |
+          ENDPOINTS=(
+            "CustomerService Health:/health"
+            "CustomerService Products:/api/commerce/products?pageNumber=1&pageSize=1"
+          )
+
+          for endpoint in "${ENDPOINTS[@]}"; do
+            IFS=':' read -r service path <<< "$endpoint"
+            url="${CUSTOMER_SERVICE_URL}${path}"
 
             echo ">>> Smoke testing ${service} via ${url}"
             curl -fsS \


### PR DESCRIPTION
## Description
This PR fixes the dev deployment gap that was causing `customerservice-dev` to fail activation in Azure Container Apps.

`CustomerService` was starting with its image-default local SQL connection string (`localhost,1433`) because the dev CD workflow did not configure `ConnectionStrings__DefaultConnection` for `customerservice-dev`. Since the service opens a database connection during startup, the container crashed before ingress could become healthy.

This change updates the dev workflow so `customerservice-dev` receives its Azure SQL connection string and required internal service endpoints during deployment, then adds direct smoke tests to catch future regressions.

## Changes Made
- Added a `Configure CustomerService DB connection and service endpoints` step to `.github/workflows/cd-dev.yml`
- Set `ConnectionStrings__DefaultConnection` for `customerservice-dev` from `customer-db-conn`
- Set `ServiceEndpoints__ProductService=http://productservice-dev`
- Set `ServiceEndpoints__OrderService=http://orderservice-dev`
- Added a `Resolve CustomerService URL` step in the dev workflow
- Added direct CustomerService smoke tests for:
  - `/health`
  - `/api/commerce/products?pageNumber=1&pageSize=1`
- Left live Azure resources unchanged; this PR only updates the deployment workflow

## How to Test
1. Trigger the `CD Dev — Migrate, Build & Push all services, Deploy to Azure` workflow.
2. Confirm the new `Configure CustomerService DB connection and service endpoints` step succeeds.
3. Confirm the new `Resolve CustomerService URL` step succeeds.
4. Confirm the new `Smoke tests — CustomerService direct endpoints` step returns `200` for both endpoints.
5. Verify `customerservice-dev` no longer starts with the fallback `localhost,1433` SQL configuration and the revision becomes healthy after deployment.

## Screenshots / Logs (if applicable)
- Previous failure in Azure logs:
  - `An error occurred using the connection to database 'insighterp_db' on server 'localhost,1433'`
  - `A network-related or instance-specific error occurred while establishing a connection to SQL Server`

## Related Issues / Tickets
- Fixes the `customerservice-dev` activation failure caused by missing dev deployment configuration for `CustomerService`
