### PR TITLE
fix:jwtresolver and unit tests

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -239,20 +239,21 @@ jobs:
             --resource-group erp-rg-prod \
             --set-env-vars "ConnectionStrings__ChurnDb=secretref:prediction-db-conn"
 
-      - name: Configure AdminService DB connection string
+      - name: Configure AdminService JWT secret and DB connection
         env:
+          JWT_SECRET: ${{ secrets.PROD_JWT_SECRET }}
           ADMIN_DB_CONN: ${{ secrets.PROD_SQL_CONNECTION_STRING_AZURE }}
         run: |
-          echo ">>> Setting ConnectionStrings__AuthDb on adminservice-prod..."
+          echo ">>> Setting JWT_SECRET and ConnectionStrings__AuthDb on adminservice-prod..."
           az containerapp secret set \
             --name adminservice-prod \
             --resource-group erp-rg-prod \
-            --secrets "auth-db-conn=$ADMIN_DB_CONN"
+            --secrets "jwt-secret=$JWT_SECRET" "auth-db-conn=$ADMIN_DB_CONN"
 
           az containerapp update \
             --name adminservice-prod \
             --resource-group erp-rg-prod \
-            --set-env-vars "ConnectionStrings__AuthDb=secretref:auth-db-conn"
+            --set-env-vars "JWT_SECRET=secretref:jwt-secret" "ConnectionStrings__AuthDb=secretref:auth-db-conn"
 
       - name: Configure ForecastService DB connection string
         env:
@@ -268,6 +269,33 @@ jobs:
             --name forecastservice-prod \
             --resource-group erp-rg-prod \
             --set-env-vars "ConnectionStrings__insighterp_db=secretref:forecast-db-conn"
+
+      - name: Verify JWT env wiring on auth path services
+        shell: bash
+        run: |
+          echo ">>> Verifying JWT_SECRET is wired on all auth path services..."
+          FAILED=0
+          for APP in authservice-prod apigateway-prod adminservice-prod; do
+            echo "Checking ${APP}..."
+            ENV_NAMES=$(az containerapp show \
+              --name "$APP" \
+              --resource-group erp-rg-prod \
+              --query "properties.template.containers[0].env[].name" \
+              -o tsv 2>/dev/null || true)
+
+            if echo "$ENV_NAMES" | grep -qx "JWT_SECRET"; then
+              echo "  ✓ JWT_SECRET is configured on ${APP}"
+            else
+              echo "  ✗ JWT_SECRET is MISSING on ${APP} — failing pipeline"
+              FAILED=1
+            fi
+          done
+
+          if [[ "$FAILED" -eq 1 ]]; then
+            echo "One or more auth path services are missing JWT_SECRET. Fix the workflow and redeploy."
+            exit 1
+          fi
+          echo ">>> JWT env wiring verified on all auth path services."
 
       - name: Resolve ApiGateway URL
         shell: bash

--- a/src/AdminService/JwtSecretResolver.cs
+++ b/src/AdminService/JwtSecretResolver.cs
@@ -1,0 +1,35 @@
+namespace AdminService;
+
+public static class JwtSecretResolver
+{
+    /// <summary>
+    /// Resolves the JWT signing secret using a fail-fast precedence contract:
+    ///   1. JWT_SECRET env var (all environments)
+    ///   2. JwtSettings:SecretKey config key (non-Production only)
+    ///
+    /// Empty, whitespace, and placeholder values (${...}) are always rejected.
+    /// In Production, only the env var is accepted; startup aborts if it is missing.
+    /// </summary>
+    /// <returns>A tuple of (resolvedSecret, sourceDescription).</returns>
+    public static (string Secret, string Source) Resolve(
+        string? envSecret,
+        string? configSecret,
+        bool isProduction)
+    {
+        if (!string.IsNullOrWhiteSpace(envSecret) && !envSecret.StartsWith("${"))
+            return (envSecret, "JWT_SECRET env var");
+
+        if (isProduction)
+            throw new InvalidOperationException(
+                "JWT_SECRET environment variable is required in Production. " +
+                "JwtSettings:SecretKey is not accepted as a production secret source. " +
+                "Ensure JWT_SECRET is injected via Azure Container Apps secrets.");
+
+        if (!string.IsNullOrWhiteSpace(configSecret) && !configSecret.StartsWith("${"))
+            return (configSecret, "JwtSettings:SecretKey (config fallback)");
+
+        throw new InvalidOperationException(
+            "No valid JWT secret configured. " +
+            "Set the JWT_SECRET environment variable or JwtSettings:SecretKey in appsettings.json.");
+    }
+}

--- a/src/AdminService/Program.cs
+++ b/src/AdminService/Program.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using AdminService;
 using AdminService.Repositories;
 using AdminService.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -8,9 +9,11 @@ using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
-var jwtSecret = Environment.GetEnvironmentVariable("JWT_SECRET")
-                ?? builder.Configuration["JwtSettings:SecretKey"]
-                ?? throw new InvalidOperationException("JwtSettings:SecretKey is not configured.");
+// JWT_SECRET env var takes precedence; JwtSettings:SecretKey is a non-Production fallback.
+var (jwtSecret, _) = JwtSecretResolver.Resolve(
+    Environment.GetEnvironmentVariable("JWT_SECRET"),
+    builder.Configuration["JwtSettings:SecretKey"],
+    builder.Environment.IsProduction());
 
 var jwtIssuer = builder.Configuration["JwtSettings:Issuer"] ?? "InsightERP";
 var jwtAudience = builder.Configuration["JwtSettings:Audience"] ?? "InsightERP-Users";

--- a/src/ApiGateway/JwtSecretResolver.cs
+++ b/src/ApiGateway/JwtSecretResolver.cs
@@ -1,0 +1,35 @@
+namespace ApiGateway;
+
+public static class JwtSecretResolver
+{
+    /// <summary>
+    /// Resolves the JWT signing secret using a fail-fast precedence contract:
+    ///   1. JWT_SECRET env var (all environments)
+    ///   2. JwtSettings:SecretKey config key (non-Production only)
+    ///
+    /// Empty, whitespace, and placeholder values (${...}) are always rejected.
+    /// In Production, only the env var is accepted; startup aborts if it is missing.
+    /// </summary>
+    /// <returns>A tuple of (resolvedSecret, sourceDescription).</returns>
+    public static (string Secret, string Source) Resolve(
+        string? envSecret,
+        string? configSecret,
+        bool isProduction)
+    {
+        if (!string.IsNullOrWhiteSpace(envSecret) && !envSecret.StartsWith("${"))
+            return (envSecret, "JWT_SECRET env var");
+
+        if (isProduction)
+            throw new InvalidOperationException(
+                "JWT_SECRET environment variable is required in Production. " +
+                "JwtSettings:SecretKey is not accepted as a production secret source. " +
+                "Ensure JWT_SECRET is injected via Azure Container Apps secrets.");
+
+        if (!string.IsNullOrWhiteSpace(configSecret) && !configSecret.StartsWith("${"))
+            return (configSecret, "JwtSettings:SecretKey (config fallback)");
+
+        throw new InvalidOperationException(
+            "No valid JWT secret configured. " +
+            "Set the JWT_SECRET environment variable or JwtSettings:SecretKey in appsettings.json.");
+    }
+}

--- a/src/ApiGateway/appsettings.Production.json
+++ b/src/ApiGateway/appsettings.Production.json
@@ -8,6 +8,7 @@
     }
   },
   "JwtSettings": {
-    "SecretKey": "${JWT_SECRET_KEY}"
+    "Issuer": "InsightERP",
+    "Audience": "InsightERP-Users"
   }
 }

--- a/src/ApiGateway/program.cs
+++ b/src/ApiGateway/program.cs
@@ -1,3 +1,4 @@
+using ApiGateway;
 using Ocelot.DependencyInjection;
 using Ocelot.Middleware;
 using Serilog;
@@ -41,9 +42,14 @@ try
     Log.Information("Ocelot Config     → {OcelotConfigFile}", selectedOcelotFile);
 
     // ── JWT settings ──────────────────────────────────────────────────────────
-    var jwtSecret   = Environment.GetEnvironmentVariable("JWT_SECRET")
-                      ?? builder.Configuration["JwtSettings:SecretKey"]
-                      ?? "your-super-secret-key-change-in-production-at-least-32-chars!!";
+    // JWT_SECRET env var takes precedence; JwtSettings:SecretKey is a non-Production fallback.
+    // Placeholder values (${...}), empty values, and missing Production secrets abort startup.
+    var (jwtSecret, jwtSecretSource) = JwtSecretResolver.Resolve(
+        Environment.GetEnvironmentVariable("JWT_SECRET"),
+        builder.Configuration["JwtSettings:SecretKey"],
+        builder.Environment.IsProduction());
+
+    Log.Information("JWT secret source  → {JwtSecretSource}", jwtSecretSource);
 
     var jwtIssuer   = builder.Configuration["JwtSettings:Issuer"]   ?? "InsightERP";
     var jwtAudience = builder.Configuration["JwtSettings:Audience"]  ?? "InsightERP-Users";

--- a/src/AuthService/JwtSecretResolver.cs
+++ b/src/AuthService/JwtSecretResolver.cs
@@ -1,0 +1,35 @@
+namespace AuthService;
+
+public static class JwtSecretResolver
+{
+    /// <summary>
+    /// Resolves the JWT signing secret using a fail-fast precedence contract:
+    ///   1. JWT_SECRET env var (all environments)
+    ///   2. JwtSettings:SecretKey config key (non-Production only)
+    ///
+    /// Empty, whitespace, and placeholder values (${...}) are always rejected.
+    /// In Production, only the env var is accepted; startup aborts if it is missing.
+    /// </summary>
+    /// <returns>A tuple of (resolvedSecret, sourceDescription).</returns>
+    public static (string Secret, string Source) Resolve(
+        string? envSecret,
+        string? configSecret,
+        bool isProduction)
+    {
+        if (!string.IsNullOrWhiteSpace(envSecret) && !envSecret.StartsWith("${"))
+            return (envSecret, "JWT_SECRET env var");
+
+        if (isProduction)
+            throw new InvalidOperationException(
+                "JWT_SECRET environment variable is required in Production. " +
+                "JwtSettings:SecretKey is not accepted as a production secret source. " +
+                "Ensure JWT_SECRET is injected via Azure Container Apps secrets.");
+
+        if (!string.IsNullOrWhiteSpace(configSecret) && !configSecret.StartsWith("${"))
+            return (configSecret, "JwtSettings:SecretKey (config fallback)");
+
+        throw new InvalidOperationException(
+            "No valid JWT secret configured. " +
+            "Set the JWT_SECRET environment variable or JwtSettings:SecretKey in appsettings.json.");
+    }
+}

--- a/src/AuthService/Program.cs
+++ b/src/AuthService/Program.cs
@@ -1,3 +1,4 @@
+using AuthService;
 using AuthService.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
@@ -7,10 +8,11 @@ using System.Text;
 var builder = WebApplication.CreateBuilder(args);
 
 // ── JWT settings ──────────────────────────────────────────────────────────────
-// Env var JWT_SECRET takes precedence; appsettings is the fallback.
-var jwtSecret   = Environment.GetEnvironmentVariable("JWT_SECRET")
-                  ?? builder.Configuration["JwtSettings:SecretKey"]
-                  ?? throw new InvalidOperationException("JwtSettings:SecretKey is not configured.");
+// JWT_SECRET env var takes precedence; JwtSettings:SecretKey is a non-Production fallback.
+var (jwtSecret, _) = JwtSecretResolver.Resolve(
+    Environment.GetEnvironmentVariable("JWT_SECRET"),
+    builder.Configuration["JwtSettings:SecretKey"],
+    builder.Environment.IsProduction());
 
 var jwtIssuer   = builder.Configuration["JwtSettings:Issuer"]   ?? "InsightERP";
 var jwtAudience = builder.Configuration["JwtSettings:Audience"]  ?? "InsightERP-Users";

--- a/tests/src/AdminService.Tests/JwtSecretResolverTests.cs
+++ b/tests/src/AdminService.Tests/JwtSecretResolverTests.cs
@@ -1,0 +1,122 @@
+using AdminService;
+
+namespace AdminService.Tests;
+
+public class JwtSecretResolverTests
+{
+    private const string ValidSecret = "valid-signing-secret-at-least-32-characters-long!!";
+
+    // ── env var is accepted ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidEnvSecret_IsAccepted_OutsideProduction()
+    {
+        var (secret, source) = JwtSecretResolver.Resolve(ValidSecret, null, isProduction: false);
+        Assert.Equal(ValidSecret, secret);
+        Assert.Contains("JWT_SECRET", source);
+    }
+
+    [Fact]
+    public void ValidEnvSecret_IsAccepted_InProduction()
+    {
+        var (secret, source) = JwtSecretResolver.Resolve(ValidSecret, null, isProduction: true);
+        Assert.Equal(ValidSecret, secret);
+        Assert.Contains("JWT_SECRET", source);
+    }
+
+    // ── env var rejection ─────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyOrWhitespaceEnvSecret_FallsThrough_ToConfigFallback(string empty)
+    {
+        var (secret, _) = JwtSecretResolver.Resolve(empty, ValidSecret, isProduction: false);
+        Assert.Equal(ValidSecret, secret);
+    }
+
+    [Fact]
+    public void PlaceholderEnvSecret_IsRejected_AndFallsThrough()
+    {
+        var (secret, _) = JwtSecretResolver.Resolve("${JWT_SECRET_KEY}", ValidSecret, isProduction: false);
+        Assert.Equal(ValidSecret, secret);
+    }
+
+    [Fact]
+    public void EmptyEnvSecret_InProduction_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve("", null, isProduction: true));
+    }
+
+    [Fact]
+    public void PlaceholderEnvSecret_InProduction_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve("${JWT_SECRET_KEY}", null, isProduction: true));
+    }
+
+    // ── config fallback ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void ConfigFallback_IsAccepted_OutsideProduction()
+    {
+        var (secret, source) = JwtSecretResolver.Resolve(null, ValidSecret, isProduction: false);
+        Assert.Equal(ValidSecret, secret);
+        Assert.Contains("JwtSettings:SecretKey", source);
+    }
+
+    [Fact]
+    public void ConfigFallback_IsRejected_InProduction()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, ValidSecret, isProduction: true));
+        Assert.Contains("Production", ex.Message);
+    }
+
+    [Fact]
+    public void PlaceholderConfigSecret_IsRejected()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, "${JWT_SECRET_KEY}", isProduction: false));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyOrWhitespaceConfigSecret_IsRejected(string empty)
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, empty, isProduction: false));
+    }
+
+    // ── both null/missing ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void BothNull_IsRejected()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, null, isProduction: false));
+    }
+
+    [Fact]
+    public void BothNull_InProduction_IsRejected()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, null, isProduction: true));
+    }
+
+    // ── env var takes precedence over config ──────────────────────────────────
+
+    [Fact]
+    public void EnvSecret_TakesPrecedenceOver_ConfigSecret()
+    {
+        const string envVal    = "env-secret-that-is-at-least-32-chars-long!!";
+        const string configVal = "config-secret-that-is-at-least-32-chars-long!!";
+
+        var (secret, source) = JwtSecretResolver.Resolve(envVal, configVal, isProduction: false);
+
+        Assert.Equal(envVal, secret);
+        Assert.Contains("JWT_SECRET", source);
+    }
+}

--- a/tests/src/ApiGateway.Tests/JwtSecretResolverTests.cs
+++ b/tests/src/ApiGateway.Tests/JwtSecretResolverTests.cs
@@ -1,0 +1,123 @@
+using ApiGateway;
+using Xunit;
+
+namespace ApiGateway.Tests;
+
+public class JwtSecretResolverTests
+{
+    private const string ValidSecret = "valid-signing-secret-at-least-32-characters-long!!";
+
+    // ── env var is accepted ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidEnvSecret_IsAccepted_OutsideProduction()
+    {
+        var (secret, source) = JwtSecretResolver.Resolve(ValidSecret, null, isProduction: false);
+        Assert.Equal(ValidSecret, secret);
+        Assert.Contains("JWT_SECRET", source);
+    }
+
+    [Fact]
+    public void ValidEnvSecret_IsAccepted_InProduction()
+    {
+        var (secret, source) = JwtSecretResolver.Resolve(ValidSecret, null, isProduction: true);
+        Assert.Equal(ValidSecret, secret);
+        Assert.Contains("JWT_SECRET", source);
+    }
+
+    // ── env var rejection ─────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyOrWhitespaceEnvSecret_FallsThrough_ToConfigFallback(string empty)
+    {
+        var (secret, _) = JwtSecretResolver.Resolve(empty, ValidSecret, isProduction: false);
+        Assert.Equal(ValidSecret, secret);
+    }
+
+    [Fact]
+    public void PlaceholderEnvSecret_IsRejected_AndFallsThrough()
+    {
+        var (secret, _) = JwtSecretResolver.Resolve("${JWT_SECRET_KEY}", ValidSecret, isProduction: false);
+        Assert.Equal(ValidSecret, secret);
+    }
+
+    [Fact]
+    public void EmptyEnvSecret_InProduction_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve("", null, isProduction: true));
+    }
+
+    [Fact]
+    public void PlaceholderEnvSecret_InProduction_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve("${JWT_SECRET_KEY}", null, isProduction: true));
+    }
+
+    // ── config fallback ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void ConfigFallback_IsAccepted_OutsideProduction()
+    {
+        var (secret, source) = JwtSecretResolver.Resolve(null, ValidSecret, isProduction: false);
+        Assert.Equal(ValidSecret, secret);
+        Assert.Contains("JwtSettings:SecretKey", source);
+    }
+
+    [Fact]
+    public void ConfigFallback_IsRejected_InProduction()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, ValidSecret, isProduction: true));
+        Assert.Contains("Production", ex.Message);
+    }
+
+    [Fact]
+    public void PlaceholderConfigSecret_IsRejected()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, "${JWT_SECRET_KEY}", isProduction: false));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyOrWhitespaceConfigSecret_IsRejected(string empty)
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, empty, isProduction: false));
+    }
+
+    // ── both null/missing ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void BothNull_IsRejected()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, null, isProduction: false));
+    }
+
+    [Fact]
+    public void BothNull_InProduction_IsRejected()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, null, isProduction: true));
+    }
+
+    // ── env var takes precedence over config ──────────────────────────────────
+
+    [Fact]
+    public void EnvSecret_TakesPrecedenceOver_ConfigSecret()
+    {
+        const string envVal    = "env-secret-that-is-at-least-32-chars-long!!";
+        const string configVal = "config-secret-that-is-at-least-32-chars-long!!";
+
+        var (secret, source) = JwtSecretResolver.Resolve(envVal, configVal, isProduction: false);
+
+        Assert.Equal(envVal, secret);
+        Assert.Contains("JWT_SECRET", source);
+    }
+}

--- a/tests/src/AuthService.Tests/JwtSecretResolverTests.cs
+++ b/tests/src/AuthService.Tests/JwtSecretResolverTests.cs
@@ -1,0 +1,122 @@
+using AuthService;
+
+namespace AuthService.Tests;
+
+public class JwtSecretResolverTests
+{
+    private const string ValidSecret = "valid-signing-secret-at-least-32-characters-long!!";
+
+    // ── env var is accepted ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidEnvSecret_IsAccepted_OutsideProduction()
+    {
+        var (secret, source) = JwtSecretResolver.Resolve(ValidSecret, null, isProduction: false);
+        Assert.Equal(ValidSecret, secret);
+        Assert.Contains("JWT_SECRET", source);
+    }
+
+    [Fact]
+    public void ValidEnvSecret_IsAccepted_InProduction()
+    {
+        var (secret, source) = JwtSecretResolver.Resolve(ValidSecret, null, isProduction: true);
+        Assert.Equal(ValidSecret, secret);
+        Assert.Contains("JWT_SECRET", source);
+    }
+
+    // ── env var rejection ─────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyOrWhitespaceEnvSecret_FallsThrough_ToConfigFallback(string empty)
+    {
+        var (secret, _) = JwtSecretResolver.Resolve(empty, ValidSecret, isProduction: false);
+        Assert.Equal(ValidSecret, secret);
+    }
+
+    [Fact]
+    public void PlaceholderEnvSecret_IsRejected_AndFallsThrough()
+    {
+        var (secret, _) = JwtSecretResolver.Resolve("${JWT_SECRET_KEY}", ValidSecret, isProduction: false);
+        Assert.Equal(ValidSecret, secret);
+    }
+
+    [Fact]
+    public void EmptyEnvSecret_InProduction_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve("", null, isProduction: true));
+    }
+
+    [Fact]
+    public void PlaceholderEnvSecret_InProduction_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve("${JWT_SECRET_KEY}", null, isProduction: true));
+    }
+
+    // ── config fallback ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void ConfigFallback_IsAccepted_OutsideProduction()
+    {
+        var (secret, source) = JwtSecretResolver.Resolve(null, ValidSecret, isProduction: false);
+        Assert.Equal(ValidSecret, secret);
+        Assert.Contains("JwtSettings:SecretKey", source);
+    }
+
+    [Fact]
+    public void ConfigFallback_IsRejected_InProduction()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, ValidSecret, isProduction: true));
+        Assert.Contains("Production", ex.Message);
+    }
+
+    [Fact]
+    public void PlaceholderConfigSecret_IsRejected()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, "${JWT_SECRET_KEY}", isProduction: false));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyOrWhitespaceConfigSecret_IsRejected(string empty)
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, empty, isProduction: false));
+    }
+
+    // ── both null/missing ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void BothNull_IsRejected()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, null, isProduction: false));
+    }
+
+    [Fact]
+    public void BothNull_InProduction_IsRejected()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            JwtSecretResolver.Resolve(null, null, isProduction: true));
+    }
+
+    // ── env var takes precedence over config ──────────────────────────────────
+
+    [Fact]
+    public void EnvSecret_TakesPrecedenceOver_ConfigSecret()
+    {
+        const string envVal    = "env-secret-that-is-at-least-32-chars-long!!";
+        const string configVal = "config-secret-that-is-at-least-32-chars-long!!";
+
+        var (secret, source) = JwtSecretResolver.Resolve(envVal, configVal, isProduction: false);
+
+        Assert.Equal(envVal, secret);
+        Assert.Contains("JWT_SECRET", source);
+    }
+}


### PR DESCRIPTION
Problem
Admin dashboard was returning 401 on every request in production because AdminService was validating JWTs with a different secret than the one AuthService used to sign them.

Two root causes:

AdminService had no JWT_SECRET in prod — cd-prod.yml configured the secret on authservice-prod and apigateway-prod but skipped adminservice-prod. The service fell through to the appsettings.json placeholder and rejected every token.

ApiGateway had a silent placeholder secret — appsettings.Production.json set JwtSettings:SecretKey to the literal string "${JWT_SECRET_KEY}". .NET does not interpolate that; it was being used as the signing key whenever JWT_SECRET was absent, causing validation to silently pass or fail against the wrong key with no startup error.

Changes
JwtSecretResolver (new — ApiGateway, AuthService, AdminService)
Extracted the secret resolution logic into a shared static class per service with a clearly defined, fail-fast contract:

Accept JWT_SECRET env var in all environments
Accept JwtSettings:SecretKey config key only outside Production
Reject empty, whitespace, and ${...} placeholder values at every step
In Production, abort startup immediately if the env var is missing or invalid
All three Program.cs files now call this instead of the old triple-null-coalesce that silently fell through to a hardcoded dev default.

appsettings.Production.json (ApiGateway)
Removed JwtSettings:SecretKey: "${JWT_SECRET_KEY}". That placeholder was never interpolated by .NET config — it was returned as a literal string and used as the signing key, causing silent token validation failures. Only Issuer and Audience (non-sensitive) remain.

cd-prod.yml
adminservice-prod now receives JWT_SECRET=secretref:jwt-secret alongside its DB connection string (was the only auth-path service missing it).
New "Verify JWT env wiring" step runs before smoke tests and fails the pipeline immediately if JWT_SECRET is absent on any of authservice-prod, apigateway-prod, or adminservice-prod.
Tests (45 new, 15 per service)
JwtSecretResolverTests covers: valid env var accepted in both environments · empty/whitespace/placeholder env var falls through or throws · config fallback accepted outside Production and rejected in Production · placeholder config rejected · both-null rejects · env var takes precedence over config.

Test plan
 All 45 new JwtSecretResolver tests pass (dotnet test --filter JwtSecretResolver)
 Full test suite green (no regressions in existing 70 tests)
 After merge to main, confirm adminservice-prod has JWT_SECRET set in Azure portal
 Confirm /admin/health returns 200
 Confirm admin dashboard loads without 401 or JSON parse errors in browser console